### PR TITLE
fix(attr): change argument type of Loop()

### DIFF
--- a/twiml/attr/attr.go
+++ b/twiml/attr/attr.go
@@ -318,9 +318,9 @@ func Length(v int) Option {
 }
 
 // Loop sets times to loop message
-func Loop(v language.Type) Option {
+func Loop(v int) Option {
 	return func(t core.XMLer) {
-		t.SetAttr(_loop, string(v))
+		t.SetAttr(_loop, strconv.Itoa(v))
 	}
 }
 


### PR DESCRIPTION
The argument type of `Loop()`, an option function of the `attr` package, appears to be wrong.
Fix the argument type to int.

Ref. https://jp.twilio.com/docs/voice/twiml/play#attributes-loop