### PR TITLE
Update WaitURL attr method to take a string

### DIFF
--- a/twiml/attr/attr.go
+++ b/twiml/attr/attr.go
@@ -679,9 +679,9 @@ func WaitMethod(v http.Method) Option {
 }
 
 // WaitURL sets wait URL
-func WaitURL(v http.Method) Option {
+func WaitURL(v string) Option {
 	return func(t core.XMLer) {
-		t.SetAttr(_waitURL, string(v))
+		t.SetAttr(_waitURL, v)
 	}
 }
 


### PR DESCRIPTION
Other URL attrs take a string as opposed to having the cast to http.Method(), which is a string anyway. Not a functional change, just semantics.